### PR TITLE
[FEAT] 1280px 미만 기기에서 잉듀 생성 및 학습 제한

### DIFF
--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -18,7 +18,7 @@ function Header() {
   });
 
   return (
-    <header className="fixed top-0 left-0 z-100 flex h-15 w-full items-center justify-between border-b border-border-default bg-surface-weak px-20">
+    <header className="fixed top-0 left-0 z-100 flex h-15 w-full items-center justify-between border-b border-border-default bg-surface-weak px-8 lg:px-16 xl:px-25">
       <Link to={'/'}>
         <div className="flex items-center gap-2">
           <img src="/logo.svg" alt="로고" className="w-9" />

--- a/src/features/engdu-learning/EngduLeaning.tsx
+++ b/src/features/engdu-learning/EngduLeaning.tsx
@@ -10,11 +10,13 @@ import { trackEvent, startRecording, stopRecording } from '@/utils/analytics';
 import FeedbackModal from './components/FeedbackModal';
 import { useEngduLearning } from '@/hooks/useEngduLearning';
 import { toast } from 'sonner';
+import { useIsDesktop } from '@/hooks/useMediaQuery';
 
 function EngduLearning() {
   const params = useParams();
   const engduId = Number(params.engduId);
   const navigate = useNavigate();
+  const isDesktop = useIsDesktop();
 
   const {
     engduDetail,
@@ -171,6 +173,19 @@ function EngduLearning() {
       });
     }
   };
+
+  if (!isDesktop) {
+    return (
+      <div className="flex h-[calc(100dvh-60px)] flex-col items-center justify-center gap-2 px-10">
+        <h2 className="text-24 font-bold text-text-primary">
+          학습은 데스크탑에서 진행해주세요
+        </h2>
+        <p className="mt-2 text-text-secondary">
+          잉듀의 학습 환경은 현재 1280px 이상의 큰 화면에서 가장 잘 보입니다.
+        </p>
+      </div>
+    );
+  }
 
   if (isPendingDetail) {
     return null;

--- a/src/features/home/components/EngduList.tsx
+++ b/src/features/home/components/EngduList.tsx
@@ -7,6 +7,8 @@ import EngduListPagination from './EngduListPagination';
 import Dropdown from './filter-section/Dropdown';
 import NewEngduButton from './filter-section/NewEngduButton';
 import EngduFullFindIcon from '@/assets/icons/engdu-full-find.svg?react';
+import EngduFullNoticeIcon from '@/assets/icons/engdu-full-notice.svg?react';
+import { useIsDesktop } from '@/hooks/useMediaQuery';
 
 interface EngduListProps {
   onOpenHandler: () => void;
@@ -33,6 +35,7 @@ function EngduList({ onOpenHandler }: EngduListProps) {
 
 function EngduListContent({ onOpenHandler }: EngduListProps) {
   const { page, sort, type, status, setSort, setStatus, setPage } = useEngduParams();
+  const isDesktop = useIsDesktop();
 
   const { data, isPending } = useQuery({
     queryKey: ['engdu', 'engdus', { page, sort, type, status }],
@@ -54,13 +57,20 @@ function EngduListContent({ onOpenHandler }: EngduListProps) {
 
   return (
     <>
+      {!isDesktop && (
+        <div className="flex items-center gap-4 rounded-xl border border-border-accent bg-surface-accent/20 px-6 py-4 text-text-accent">
+          <EngduFullNoticeIcon className="h-6 w-6" />
+          <span>잉듀 생성 및 학습은 1280px 이상의 데스크탑에서 진행해주세요.</span>
+        </div>
+      )}
+
       {/* 필터링 버튼, 생성 버튼 */}
       <div className="flex flex-col justify-between gap-2.5 md:flex-row">
         <div className="flex gap-2.5">
           <Dropdown filterKey="sort" value={sort} setValue={setSort} />
           <Dropdown filterKey="status" value={status} setValue={setStatus} />
         </div>
-        <NewEngduButton onOpenHandler={onOpenHandler} />
+        {isDesktop && <NewEngduButton onOpenHandler={onOpenHandler} />}
       </div>
 
       {/* 잉듀 목록 */}

--- a/src/features/home/components/engdu-cards-section/EmptyCard.tsx
+++ b/src/features/home/components/engdu-cards-section/EmptyCard.tsx
@@ -1,11 +1,14 @@
 import FileIcon from '@/assets/icons/file-text.svg?react';
 import NewEngduButton from '../filter-section/NewEngduButton';
+import { useIsDesktop } from '@/hooks/useMediaQuery';
 
 interface EmptyCardProps {
   onOpenHandler: () => void;
 }
 
 function EmptyCard({ onOpenHandler }: EmptyCardProps) {
+  const isDesktop = useIsDesktop();
+
   return (
     <div className="flex w-full flex-col items-center gap-5 rounded-2xl border-4 border-dashed border-border-default bg-surface-weak py-20">
       <div className="flex aspect-square w-24 items-center justify-center rounded-full bg-surface-brand-default/16">
@@ -13,7 +16,7 @@ function EmptyCard({ onOpenHandler }: EmptyCardProps) {
       </div>
       <div className="font-pinkfong text-24">아직 생성된 잉듀가 없어요!</div>
       <div className="text-text-secondary">원하는 주제로 첫 번째 잉듀를 만들어보세요.</div>
-      <NewEngduButton onOpenHandler={onOpenHandler} />
+      {isDesktop && <NewEngduButton onOpenHandler={onOpenHandler} />}
     </div>
   );
 }

--- a/src/hooks/useMediaQuery.ts
+++ b/src/hooks/useMediaQuery.ts
@@ -1,0 +1,21 @@
+import { useState, useEffect } from 'react';
+
+export function useMediaQuery(query: string) {
+  const [matches, setMatches] = useState(false);
+
+  useEffect(() => {
+    const media = window.matchMedia(query);
+    if (media.matches !== matches) {
+      setMatches(media.matches);
+    }
+    const listener = () => setMatches(media.matches);
+    media.addEventListener('change', listener);
+    return () => media.removeEventListener('change', listener);
+  }, [matches, query]);
+
+  return matches;
+}
+
+export function useIsDesktop() {
+  return useMediaQuery('(min-width: 1280px)');
+}


### PR DESCRIPTION
## ✨ PR 유형

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] UI 변경(스타일 파일 추가 및 수정 등)
- [ ] 문서 작성 및 수정
- [ ] 테스트 코드 추가
- [ ] 코드에 영향을 주지 않는 변경사항 (변수명 변경, 오타 수정, 주석 추가 등)
- [ ] 기타 (설정 추가 등)

---

## ✅ 완료 작업 목록

- [x] 화면 크기 감지를 위한 [useMediaQuery](cci:1://file:///Users/hanjieun/develop/eng-du/src/hooks/useMediaQuery.ts:2:0-16:1) 커스텀 훅 추가 (Tailwind xl: 1280px 기준)
- [x] 1280px 미만 기기에서 학습 페이지 접근 제한 및 안내 문구 노출
- [x] 잉듀 목록 및 빈 화면에서 1280px 미만일 시 생성 버튼 숨김 처리
- [x] 1280px 미만 환경을 위한 생성 및 학습 데스크탑 권장 안내 박스 추가
- [x] 헤더(Header) 컴포넌트에 반응형 패딩(px-8 lg:px-16 xl:px-25) 적용 및 레이아웃 개선

---

## 📸 스크린샷
