### PR TITLE
[PERF] Amplitude 지연 로딩 추가

### DIFF
--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -1,19 +1,15 @@
-import * as amplitude from '@amplitude/analytics-browser';
-import { sessionReplayPlugin } from '@amplitude/plugin-session-replay-browser';
-
 const AMPLITUDE_API_KEY = import.meta.env.VITE_AMPLITUDE_API_KEY;
+const REPLAY_SAMPLE_RATE = 0.1;
 
-const sessionReplay = sessionReplayPlugin({
-  sampleRate: 1.0,
-});
+let amplitudeModule: typeof import('@amplitude/analytics-browser') | null = null;
+let isInitializing = false;
+let sessionReplayPluginInstance: any = null;
 
-export const startRecording = () => {
-  amplitude.add(sessionReplay);
-};
-
-export const stopRecording = () => {
-  amplitude.remove(sessionReplay.name!);
-};
+async function loadAmplitude() {
+  if (amplitudeModule) return amplitudeModule;
+  amplitudeModule = await import('@amplitude/analytics-browser');
+  return amplitudeModule;
+}
 
 export type EventMap = {
   engdu_modal_open: { entry_point: string };
@@ -47,27 +43,81 @@ export type EventMap = {
   };
 };
 
+/**
+ * 1. Analytics 초기화 (Idle 시점에 로드)
+ */
 export const initAmplitude = () => {
-  if (!AMPLITUDE_API_KEY) {
-    console.warn('Amplitude API Key is missing. Analytics will not be sent.');
-    return;
+  if (!AMPLITUDE_API_KEY || isInitializing || amplitudeModule) return;
+  isInitializing = true;
+
+  const initialize = async () => {
+    try {
+      const amp = await loadAmplitude();
+      amp.init(AMPLITUDE_API_KEY, undefined, {
+        defaultTracking: {
+          sessions: true,
+        },
+        minIdLength: 1,
+        logLevel: import.meta.env.PROD ? 0 : 3, // None : Debug
+      });
+    } catch (error) {
+      console.error('Failed to initialize Amplitude:', error);
+    } finally {
+      isInitializing = false;
+    }
+  };
+
+  if ('requestIdleCallback' in window) {
+    window.requestIdleCallback(() => initialize(), { timeout: 5000 });
+  } else {
+    setTimeout(initialize, 3000);
   }
-  amplitude.init(AMPLITUDE_API_KEY, undefined, {
-    defaultTracking: {
-      sessions: true,
-    },
-    minIdLength: 1,
-    logLevel: import.meta.env.PROD ? amplitude.Types.LogLevel.None : amplitude.Types.LogLevel.Debug,
-  });
 };
 
-export const trackEvent = <K extends keyof EventMap>(
+/**
+ * 2. Session Replay 시작 (실제 호출 시점에만 SDK 로드)
+ */
+export const startRecording = async () => {
+  try {
+    const amp = await loadAmplitude();
+    
+    if (!sessionReplayPluginInstance) {
+      // Replay 플러그인과 그 의존성(rrweb 등)을 이 시점에만 로드
+      const { sessionReplayPlugin } = await import('@amplitude/plugin-session-replay-browser');
+      sessionReplayPluginInstance = sessionReplayPlugin({
+        sampleRate: REPLAY_SAMPLE_RATE,
+      });
+      amp.add(sessionReplayPluginInstance);
+    }
+  } catch (error) {
+    console.error('Failed to start Session Replay:', error);
+  }
+};
+
+export const stopRecording = async () => {
+  if (amplitudeModule && sessionReplayPluginInstance) {
+    amplitudeModule.remove(sessionReplayPluginInstance.name);
+  }
+};
+
+/**
+ * 3. 이벤트 트래킹 (초기화 전 호출 시 자동 로드)
+ */
+export const trackEvent = async <K extends keyof EventMap>(
   eventName: K,
   eventProperties: EventMap[K],
 ) => {
-  amplitude.track(eventName, eventProperties);
+  try {
+    const amp = await loadAmplitude();
+    amp.track(eventName, eventProperties);
+  } catch (error) {
+    // 분석 도구 오류가 앱 로직에 영향을 주지 않도록 swallow
+  }
 };
 
-export const setUserId = (userId: string | number) => {
-  amplitude.setUserId(userId.toString());
+export const setUserId = async (userId: string | number) => {
+  try {
+    const amp = await loadAmplitude();
+    amp.setUserId(userId.toString());
+  } catch (error) {}
 };


### PR DESCRIPTION
## ✨ PR 유형

- [ ]  새로운 기능 추가
- [ ]  버그 수정
- [ ]  UI 변경(스타일 파일 추가 및 수정 등)
- [ ]  문서 작성 및 수정
- [ ]  테스트 코드 추가
- [ ]  코드에 영향을 주지 않는 변경사항 (변수명 변경, 오타 수정, 주석 추가 등)
- [x]  기타 (설정 추가 등)

---

## ✅ 완료 작업 목록

- [x] Amplitude SDK를 dynamic import 기반으로 지연 로딩하도록 변경
- [x] requestIdleCallback 기반 analytics 초기화 적용
- [x] Session Replay SDK를 recording 시점에만 로드하도록 분리
- [x] nginx 정적 asset immutable cache 설정 추가

---

## 📸 스크린샷

<img width="2940" height="1662" alt="image" src="https://github.com/user-attachments/assets/581f102a-6c75-4563-9265-00ce8a1fa3d1" />
