### PR TITLE
[FIX] EngduCallout 컴포넌트의 Icon 타입 에러 수정

### DIFF
--- a/src/components/EngduCallout/EngduCallout.tsx
+++ b/src/components/EngduCallout/EngduCallout.tsx
@@ -1,9 +1,9 @@
-import type { ReactNode, ElementType } from 'react';
+import type { ComponentType, ReactNode } from 'react';
 import { cn } from '@/utils/cn';
 
 interface EngduCalloutProps {
   children: ReactNode;
-  Icon: ElementType;
+  Icon: ComponentType<{ className?: string }>;
   onClickHandler?: () => void;
   className?: string;
 }


### PR DESCRIPTION
EngduCallout 컴포넌트의 Icon props 타입이 ElementType으로 정의되어 있어 발생하던 빌드 에러를 ComponentType<{ className?: string }>으로 수정합니다. (#80)