### PR TITLE
[FEAT] 런앤런 모바일 고정 카드 및 하단 탭 레이아웃 구현 (#87)

### DIFF
--- a/src/assets/game/start/start_mobile_bg.svg
+++ b/src/assets/game/start/start_mobile_bg.svg
@@ -1,0 +1,3 @@
+<svg preserveAspectRatio="none" width="100%" height="100%" overflow="visible" style="display: block;" viewBox="0 0 327 225" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path id="Vector" d="M244.288 2.20679C276.475 -1.19642 298.147 -0.798442 327 4.34563V225L113.875 224.999H0V49.2081C23.0824 35.0751 46.0821 27.7974 77.5824 24.8413C100.494 22.6911 123.747 24.8413 156.838 35.0751C185.3 13.7399 215.435 9.19666 244.288 2.20679Z" fill="var(--fill-0, #B6EA82)"/>
+</svg>

--- a/src/assets/game/start/start_mobile_intersect.svg
+++ b/src/assets/game/start/start_mobile_intersect.svg
@@ -1,0 +1,3 @@
+<svg preserveAspectRatio="none" width="100%" height="100%" overflow="visible" style="display: block;" viewBox="0 0 294 178" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path id="Intersect" d="M294 178H0C82.1333 77.9821 178.461 36.6585 294 0V178Z" fill="var(--fill-0, #E0AC7C)"/>
+</svg>

--- a/src/features/run-and-learn/RunAndLearn.tsx
+++ b/src/features/run-and-learn/RunAndLearn.tsx
@@ -1,46 +1,111 @@
-import { Suspense } from 'react';
+import { Suspense, useState } from 'react';
+import { cn } from '@/utils/cn';
 import GameScene from './components/game-scene/GameScene';
 import Ranking from './components/ranking/Ranking';
 
 export default function RunAndLearn() {
+  const [activeTab, setActiveTab] = useState<'game' | 'ranking'>('game');
+
   return (
-    <div className="relative flex h-[calc(100vh-3.75rem)] items-center justify-center bg-surface-default p-4 sm:p-6 lg:p-8 animate-fade-in-up overflow-hidden">
-      <div className="flex flex-row gap-6 items-stretch justify-center w-full max-w-[1640px] h-full max-h-[890px]">
-        {/* 왼쪽 사이드바 (튜토리얼 및 랭킹) */}
-        <div className="flex flex-col gap-6 flex-1 min-w-[320px] max-w-[360px] h-full px-2.5 py-2.5">
-          <Ranking />
+    <div className="relative flex flex-col h-[calc(100dvh-3.75rem)] w-full bg-surface-default overflow-hidden animate-fade-in-up">
+      {/* 메인 콘텐츠 영역 */}
+      <div className="flex-1 flex items-center justify-center p-0 md:p-6 lg:p-8 overflow-hidden">
+        {/* 데스크톱 레이아웃 (1024px/lg 이상에서만 좌우 분할 구조 노출) */}
+        <div className="hidden lg:flex flex-row gap-6 items-stretch justify-center w-full max-w-[1640px] h-full max-h-[890px]">
+          {/* 왼쪽 사이드바 (랭킹) */}
+          <div className="flex flex-col gap-6 flex-1 min-w-[320px] max-w-[360px] h-full px-2.5 py-2.5">
+            <Ranking />
+          </div>
+
+          {/* 오른쪽 3D 게임 화면 */}
+          <div 
+            className="
+              w-[min(77.5%,calc(100%-344px),calc((100vh-3.75rem-2rem)*1240/890),1240px)]
+              sm:w-[min(77.5%,calc(100%-344px),calc((100vh-3.75rem-3rem)*1240/890),1240px)]
+              lg:w-[min(77.5%,calc(100%-344px),calc((100vh-3.75rem-4rem)*1240/890),1240px)]
+              aspect-[1240/890] 
+              rounded-2xl 
+              overflow-hidden 
+              bg-slate-950 
+              shadow-default 
+              relative 
+              self-center
+              shrink-0
+            "
+          >
+            <Suspense fallback={
+              <div className="absolute inset-0 flex flex-col items-center justify-center bg-slate-950/95 z-50">
+                <div className="relative flex items-center justify-center mb-4">
+                  <div className="animate-spin rounded-full h-16 w-16 border-4 border-t-indigo-500 border-r-indigo-500 border-b-slate-800 border-l-slate-800"></div>
+                  <span className="absolute text-12 font-bold font-mono text-indigo-400">3D</span>
+                </div>
+                <span className="text-14 font-medium text-slate-300 font-sans tracking-wide">
+                  3D 월드 리소스를 로딩하는 중...
+                </span>
+              </div>
+            }>
+              <GameScene />
+            </Suspense>
+          </div>
         </div>
 
-        {/* 오른쪽 3D 게임 화면 */}
-        <div 
-          className="
-            w-[min(77.5%,calc(100%-344px),calc((100vh-3.75rem-2rem)*1240/890),1240px)]
-            sm:w-[min(77.5%,calc(100%-344px),calc((100vh-3.75rem-3rem)*1240/890),1240px)]
-            lg:w-[min(77.5%,calc(100%-344px),calc((100vh-3.75rem-4rem)*1240/890),1240px)]
-            aspect-[1240/890] 
-            rounded-2xl 
-            overflow-hidden 
-            bg-slate-950 
-            shadow-default 
-            relative 
-            self-center
-            shrink-0
-          "
-        >
-          <Suspense fallback={
-            <div className="absolute inset-0 flex flex-col items-center justify-center bg-slate-950/95 z-50">
-              <div className="relative flex items-center justify-center mb-4">
-                <div className="animate-spin rounded-full h-16 w-16 border-4 border-t-indigo-500 border-r-indigo-500 border-b-slate-800 border-l-slate-800"></div>
-                <span className="absolute text-12 font-bold font-mono text-indigo-400">3D</span>
+        {/* 모바일 및 태블릿 레이아웃 (1024px/lg 미만 구조 - 탭 전환 방식) */}
+        <div className="lg:hidden flex flex-col items-center justify-center w-full h-full p-6">
+          {/* 모바일/태블릿 게임 카드 (md 미만 세로 카드비율 / md~lg 사이 데스크톱형 가로카드비율) */}
+          <div 
+            className={cn(
+              // 모바일 (md 미만): 327:592 세로 카드 비율
+              "w-[min(100%,calc((100dvh-3.75rem-64px-48px)*327/592))] aspect-[327/592] rounded-[32px] overflow-hidden bg-slate-950 shadow-default relative self-center shrink-0",
+              // 태블릿 (md 이상 lg 미만): 1240:890 가로 넓은 카드 비율로 자동 핏
+              "md:w-[min(100%,calc((100dvh-3.75rem-64px-48px)*1240/890))] md:aspect-[1240/890] md:rounded-2xl",
+              activeTab === 'game' ? 'block' : 'hidden'
+            )}
+          >
+            <Suspense fallback={
+              <div className="absolute inset-0 flex flex-col items-center justify-center bg-slate-950/95 z-50">
+                <div className="relative flex items-center justify-center mb-4">
+                  <div className="animate-spin rounded-full h-16 w-16 border-4 border-t-indigo-500 border-r-indigo-500 border-b-slate-800 border-l-slate-800"></div>
+                  <span className="absolute text-12 font-bold font-mono text-indigo-400">3D</span>
+                </div>
+                <span className="text-14 font-medium text-slate-300 font-sans tracking-wide">
+                  3D 월드 리소스를 로딩하는 중...
+                </span>
               </div>
-              <span className="text-14 font-medium text-slate-300 font-sans tracking-wide">
-                3D 월드 리소스를 로딩하는 중...
-              </span>
-            </div>
-          }>
-            <GameScene />
-          </Suspense>
+            }>
+              <GameScene />
+            </Suspense>
+          </div>
+
+          {/* 모바일/태블릿 리더보드 (activeTab이 ranking일 때만 표시하며 컴포넌트는 유지) */}
+          <div 
+            className={cn(
+              "w-full h-full max-w-[480px] flex flex-col gap-6 px-2 py-2",
+              activeTab === 'ranking' ? 'block' : 'hidden'
+            )}
+          >
+            <Ranking />
+          </div>
         </div>
+      </div>
+
+      {/* 모바일 및 태블릿 하단 탭 바 (1024px/lg 미만) */}
+      <div className="lg:hidden flex h-16 w-full border-t border-border-default bg-surface-weak shrink-0">
+        <button
+          onClick={() => setActiveTab('game')}
+          className={`flex-1 flex items-center justify-center font-pinkfong font-bold text-20 h-full border-t-2 transition-colors duration-150 ${
+            activeTab === 'game' ? 'text-text-brand-primary border-surface-brand-default' : 'text-text-secondary border-transparent'
+          }`}
+        >
+          게임
+        </button>
+        <button
+          onClick={() => setActiveTab('ranking')}
+          className={`flex-1 flex items-center justify-center font-pinkfong font-bold text-20 h-full border-t-2 transition-colors duration-150 ${
+            activeTab === 'ranking' ? 'text-text-brand-primary border-surface-brand-default' : 'text-text-secondary border-transparent'
+          }`}
+        >
+          리더보드
+        </button>
       </div>
     </div>
   );

--- a/src/features/run-and-learn/components/common/GameButton.tsx
+++ b/src/features/run-and-learn/components/common/GameButton.tsx
@@ -6,7 +6,7 @@ interface GameButtonProps {
   disabled?: boolean;
   isLoading?: boolean;
   variant?: 'primary' | 'secondary';
-  size?: 'md' | 'lg';
+  size?: 'sm' | 'md' | 'lg';
   className?: string;
   children: ReactNode;
 }
@@ -28,8 +28,13 @@ export default function GameButton({
       onClick={disabled || isLoading ? undefined : onClick}
       disabled={disabled || isLoading}
       className={cn(
-        'flex items-center justify-center shrink-0 pb-1',
-        'w-[259px] h-[69px] rounded-full border-solid',
+        'flex items-center justify-center shrink-0 pb-1 border-solid',
+        
+        // 반응형 버튼 크기 및 테두리 반경 설정
+        size === 'lg' && 'w-[140px] h-[46px] rounded-[100px] md:w-[259px] md:h-[69px] md:rounded-full',
+        size === 'md' && 'w-[140px] h-[46px] rounded-[100px] md:w-[259px] md:h-[69px] md:rounded-full',
+        size === 'sm' && 'w-[140px] h-[46px] rounded-[100px] md:w-[180px] md:h-[54px] md:rounded-full',
+        
         isPrimary
           ? 'bg-surface-brand-default border-[#314778] border-b-4 shadow-md shadow-blue-600/20'
           : 'bg-surface-weak border-border-default border-b-4 shadow-sm',
@@ -44,7 +49,11 @@ export default function GameButton({
         className={cn(
           'font-pinkfong font-bold text-center leading-none whitespace-nowrap shrink-0',
           isPrimary ? 'text-text-weak' : 'text-text-primary',
-          size === 'lg' ? 'text-[40px]' : 'text-32'
+          
+          // 반응형 텍스트 크기 설정
+          size === 'lg' && 'text-24 md:text-[40px]',
+          size === 'md' && 'text-24 md:text-32',
+          size === 'sm' && 'text-[20px] md:text-[24px]'
         )}
       >
         {children}

--- a/src/features/run-and-learn/components/game-scene/GameOverModal.stories.tsx
+++ b/src/features/run-and-learn/components/game-scene/GameOverModal.stories.tsx
@@ -6,17 +6,30 @@ const meta = {
   component: GameOverModal,
   tags: ['autodocs'],
   parameters: {
-    layout: 'centered',
+    layout: 'fullscreen',
+    viewport: {
+      // 툴바의 뷰포트 셀렉터에 런앤런 전용 카드 해상도 등록
+      viewports: {
+        mobileCard: {
+          name: 'Mobile Card (327x592)',
+          styles: { width: '327px', height: '592px' },
+        },
+        tabletCard: {
+          name: 'Tablet Card (768x550)',
+          styles: { width: '768px', height: '550px' },
+        },
+        desktopCard: {
+          name: 'Desktop Card (1240x890)',
+          styles: { width: '1240px', height: '890px' },
+        },
+      },
+      defaultViewport: 'desktopCard', // 기본 실행은 데스크톱 카드 크기
+    },
   },
   decorators: [
     (Story) => (
-      <div className="relative w-[1240px] h-[890px] bg-slate-800 overflow-hidden">
-        <div 
-          className="absolute w-[1240px] h-[890px] left-1/2 top-1/2 pointer-events-none z-10 overflow-hidden"
-          style={{ transform: 'translate(-50%, -50%) scale(1)' }}
-        >
-          <Story />
-        </div>
+      <div className="relative w-screen h-screen bg-slate-800 flex items-center justify-center overflow-hidden">
+        <Story />
       </div>
     ),
   ],
@@ -29,14 +42,6 @@ export const Default: Story = {
   args: {
     isOpen: true,
     correctCount: 7,
-    onRestart: () => console.log('Restart clicked'),
-  },
-};
-
-export const HighScore: Story = {
-  args: {
-    isOpen: true,
-    correctCount: 14,
     onRestart: () => console.log('Restart clicked'),
   },
 };

--- a/src/features/run-and-learn/components/game-scene/GameOverModal.tsx
+++ b/src/features/run-and-learn/components/game-scene/GameOverModal.tsx
@@ -1,34 +1,61 @@
 import Modal from '@/components/Modal/Modal';
 import GameButton from '../common/GameButton';
+import { cn } from '@/utils/cn';
 
 interface GameOverModalProps {
   isOpen: boolean;
   correctCount: number;
   onRestart: () => void;
+  isMobile?: boolean;
 }
 
 /** 🏆 게임오버 시 뜨는 핑크퐁 디자인의 모달 팝업 */
-export default function GameOverModal({ isOpen, correctCount, onRestart }: GameOverModalProps) {
+export default function GameOverModal({
+  isOpen,
+  correctCount,
+  onRestart,
+  isMobile = false,
+}: GameOverModalProps) {
   return (
     <Modal
       isOpen={isOpen}
       onCloseHandler={() => { }} // 빈 함수로 백드롭/ESC 닫기 차단
       position="absolute"
-      className="bg-[#FDF8ED] px-15 py-10 overflow-hidden pointer-events-auto"
+      className={cn(
+        "bg-[#FDF8ED] max-w-[calc(100%-32px)] overflow-hidden pointer-events-auto",
+        isMobile ? "w-[280px] p-5" : "w-[560px] p-10"
+      )}
     >
-      <div className="flex flex-col gap-7 items-center justify-center w-full">
+      <div className={cn(
+        "flex flex-col items-center justify-center w-full",
+        isMobile ? "gap-5" : "gap-7"
+      )}>
         <p
-          className="font-pinkfong font-bold text-80 text-text-danger tracking-[8px] text-center select-none m-0 leading-none whitespace-nowrap"
+          className={cn(
+            "font-pinkfong font-bold text-text-danger tracking-[4px] text-center select-none m-0 leading-[1.2]",
+            isMobile
+              ? "text-32 whitespace-normal"
+              : "text-80 tracking-[8px] whitespace-nowrap leading-none"
+          )}
         >
-          GAME OVER!
+          {isMobile ? (
+            <>
+              GAME<br />OVER!
+            </>
+          ) : (
+            "GAME OVER!"
+          )}
         </p>
-        <p className="font-pinkfong font-bold text-32 text-text-primary text-center select-none m-0 leading-none mt-2">
+        <p className={cn(
+          "font-pinkfong font-bold text-text-primary text-center select-none m-0 leading-none",
+          isMobile ? "text-20 mt-1" : "text-32 mt-2"
+        )}>
           이번 점수: {correctCount * 10}점
         </p>
         <GameButton
           onClick={onRestart}
-          className="mt-6"
-          size="md"
+          className={isMobile ? "mt-3" : "mt-6"}
+          size={isMobile ? "sm" : "md"}
         >
           재도전
         </GameButton>

--- a/src/features/run-and-learn/components/game-scene/GameScene.tsx
+++ b/src/features/run-and-learn/components/game-scene/GameScene.tsx
@@ -1,5 +1,6 @@
 import { Suspense, useRef, useEffect, useState, useCallback } from 'react';
-import { Canvas, useFrame } from '@react-three/fiber';
+import { PerspectiveCamera } from 'three';
+import { Canvas, useFrame, useThree } from '@react-three/fiber';
 import { useQueryClient } from '@tanstack/react-query';
 import Background from './Background';
 import Pathway from './Pathway';
@@ -15,8 +16,25 @@ import LightbulbIcon from '@/assets/game/lightbulb.svg?react';
 import MovingAnswerWall from './MovingAnswerWall';
 import GameOverModal from './GameOverModal';
 
-// 카메라 시선 고정 헬퍼
-function CameraController() {
+// 카메라 시선 고정 및 모바일 반응형 FOV/위치 헬퍼
+function CameraController({ aspect }: { aspect: number }) {
+  const { camera } = useThree();
+
+  useEffect(() => {
+    if (camera instanceof PerspectiveCamera) {
+      if (aspect < 1.2) {
+        // 모바일(세로 카드 모드) 설정: 카메라 높이(Y)를 기존 0.3에서 0.8로 살짝 높임
+        camera.position.set(0, 1.0, 8.0);
+        camera.fov = 40; // 원하는 시야각(FOV)으로 여기서 직접 조절하실 수 있습니다.
+      } else {
+        // PC 설정: 기존 기본값으로 복원
+        camera.position.set(0, 0.3, 8.0);
+        camera.fov = 26;
+      }
+      camera.updateProjectionMatrix();
+    }
+  }, [aspect, camera]);
+
   useFrame((state) => {
     state.camera.lookAt(0, 0.3, -5.0);
   });
@@ -38,6 +56,7 @@ export default function GameScene() {
   } = useGameState();
   const [sessionId, setSessionId] = useState<number | null>(null);
   const containerRef = useRef<HTMLDivElement>(null);
+  const touchStartRef = useRef<{ x: number; y: number } | null>(null);
   const [isGameOverModalOpen, setIsGameOverModalOpen] = useState(false);
   const [isStarting, setIsStarting] = useState(false);
 
@@ -53,6 +72,7 @@ export default function GameScene() {
   }, [restart]);
 
   const [scale, setScale] = useState(1);
+  const [aspect, setAspect] = useState(1240 / 890);
   const BASE_WIDTH = 1240;
   const BASE_HEIGHT = 890;
 
@@ -65,6 +85,7 @@ export default function GameScene() {
       const scaleX = width / BASE_WIDTH;
       const scaleY = height / BASE_HEIGHT;
       setScale(Math.min(scaleX, scaleY));
+      setAspect(width / height);
     });
 
     observer.observe(container);
@@ -91,7 +112,7 @@ export default function GameScene() {
 
       // 3. 완료 시 즉시 PLAYING 단계로 전환
       setPhase('PLAYING');
-    } catch (err) {
+    } catch {
       setSessionId(null);
     } finally {
       setIsStarting(false);
@@ -171,6 +192,32 @@ export default function GameScene() {
     return () => window.removeEventListener('keydown', handleKeyDown);
   }, [phase, setLane]);
 
+  // 🕹️ MOBILE GESTURE (SWIPE) INTERACTION
+  const handleTouchStart = useCallback((e: React.TouchEvent) => {
+    if (phase !== 'PLAYING') return;
+    const touch = e.touches[0];
+    touchStartRef.current = { x: touch.clientX, y: touch.clientY };
+  }, [phase]);
+
+  const handleTouchEnd = useCallback((e: React.TouchEvent) => {
+    if (phase !== 'PLAYING' || !touchStartRef.current) return;
+    const touch = e.changedTouches[0];
+    const deltaX = touch.clientX - touchStartRef.current.x;
+    const deltaY = touch.clientY - touchStartRef.current.y;
+
+    const threshold = 50; // 스와이프 최소 픽셀 임계값 (값을 높일수록 더 많이 쓸어넘겨야 조작되어 감도가 낮아집니다)
+
+    // 가로 이동 거리가 세로보다 크고 스레숄드를 넘었을 경우에만 스와이프로 인정
+    if (Math.abs(deltaX) > Math.abs(deltaY) && Math.abs(deltaX) > threshold) {
+      if (deltaX < 0) {
+        setLane((prev) => Math.max(0, prev - 1)); // 왼쪽 스와이프 -> 왼쪽 이동
+      } else {
+        setLane((prev) => Math.min(2, prev + 1)); // 오른쪽 스와이프 -> 오른쪽 이동
+      }
+    }
+    touchStartRef.current = null;
+  }, [phase, setLane]);
+
   // Exact X-coordinate conversions for pixel-perfect centering in 3D
   const lanes = [-1.54, 0.0, 1.54];
   const targetX = lanes[lane];
@@ -179,7 +226,10 @@ export default function GameScene() {
     <div
       ref={containerRef}
       tabIndex={0}
-      className="absolute inset-0 w-full h-full overflow-hidden outline-none"
+      className="absolute inset-0 w-full h-full overflow-hidden outline-none select-none"
+      style={{ touchAction: 'none' }}
+      onTouchStart={handleTouchStart}
+      onTouchEnd={handleTouchEnd}
     >
       {/* 시작 화면 (IDLE 상태일 때만 노출) */}
       {phase === 'IDLE' && (
@@ -189,40 +239,74 @@ export default function GameScene() {
         />
       )}
 
-      {/* HTML OVERLAY UI (상태에 따른 인터페이스 오버레이, scale에 따라 정밀 축소) */}
-      <div 
-        className="absolute w-[1240px] h-[890px] left-1/2 top-1/2 pointer-events-none z-10 overflow-hidden"
-        style={{ 
-          transform: `translate(-50%, -50%) scale(${scale})`,
-          transformOrigin: 'center center'
-        }}
-      >
-        {/* 상단 현재 문제 (게임 진행 및 게임오버 상태에서 노출) */}
-        {(phase === 'PLAYING' || phase === 'CORRECT_PASSING' || phase === 'NEXT' || phase === 'GAME_OVER') && currentQuestion && (
-          <div className="absolute top-8 left-1/2 -translate-x-1/2 bg-surface-weak px-6 py-5 rounded-full text-center z-50">
-            <h3 className="text-32 font-pinkfong font-bold whitespace-nowrap">{currentQuestion.question}</h3>
-          </div>
-        )}
-
-        {/* 정답 통과 중 및 게임오버 시 해설 노출 */}
-        {(phase === 'CORRECT_PASSING' || phase === 'GAME_OVER') && currentQuestion?.explanation && (
-          <div className="absolute top-36 left-1/2 -translate-x-1/2 bg-surface-accent border border-border-accent flex items-center gap-3 px-6 py-4 rounded-2xl shadow-lg z-50 animate-fade-in-up">
-            <div className="w-6 h-[31px] flex-shrink-0 flex items-center justify-center">
-              <LightbulbIcon className="w-full h-full object-contain" />
+      {/* HTML OVERLAY UI (상태에 따른 인터페이스 오버레이, 모바일/데스크톱 대응) */}
+      {aspect < 1.2 ? (
+        /* HTML OVERLAY UI (모바일 반응형 카드 내부 레이아웃) */
+        <div className="absolute inset-0 w-full h-full pointer-events-none z-10 overflow-hidden">
+          {/* 상단 현재 문제 (게임 진행 및 게임오버 상태에서 노출) */}
+          {(phase === 'PLAYING' || phase === 'CORRECT_PASSING' || phase === 'NEXT' || phase === 'GAME_OVER') && currentQuestion && (
+            <div className="absolute top-6 left-6 right-6 bg-surface-weak px-4 py-3 rounded-2xl text-center z-50 shadow-md">
+              <h3 className="text-16 sm:text-20 font-pinkfong font-bold break-keep">{currentQuestion.question}</h3>
             </div>
-            <p className="font-pinkfong font-bold text-20 text-text-primary text-left break-keep">
-              {currentQuestion.explanation}
-            </p>
-          </div>
-        )}
+          )}
 
-        {/* 게임오버 모달 (scale 축소 영역 내부로 진입하여 함께 축소되도록 함) */}
-        <GameOverModal
-          isOpen={isGameOverModalOpen}
-          correctCount={correctCount}
-          onRestart={handleRestart}
-        />
-      </div>
+          {/* 정답 통과 중 및 게임오버 시 해설 노출 */}
+          {(phase === 'CORRECT_PASSING' || phase === 'GAME_OVER') && currentQuestion?.explanation && (
+            <div className="absolute top-28 left-6 right-6 bg-surface-accent border border-border-accent flex items-center gap-3 px-4 py-3 rounded-xl shadow-lg z-50 animate-fade-in-up">
+              <div className="w-5 h-[24px] flex-shrink-0 flex items-center justify-center">
+                <LightbulbIcon className="w-full h-full object-contain" />
+              </div>
+              <p className="font-pinkfong font-bold text-14 text-text-primary text-left break-keep">
+                {currentQuestion.explanation}
+              </p>
+            </div>
+          )}
+
+          {/* 게임오버 모달 (카드 중앙 정렬) */}
+          <GameOverModal
+            isOpen={isGameOverModalOpen}
+            correctCount={correctCount}
+            onRestart={handleRestart}
+            isMobile={true}
+          />
+        </div>
+      ) : (
+        /* HTML OVERLAY UI (기존 데스크톱 고정 디자인) */
+        <div
+          className="absolute w-[1240px] h-[890px] left-1/2 top-1/2 pointer-events-none z-10 overflow-hidden"
+          style={{
+            transform: `translate(-50%, -50%) scale(${scale})`,
+            transformOrigin: 'center center'
+          }}
+        >
+          {/* 상단 현재 문제 */}
+          {(phase === 'PLAYING' || phase === 'CORRECT_PASSING' || phase === 'NEXT' || phase === 'GAME_OVER') && currentQuestion && (
+            <div className="absolute top-8 left-1/2 -translate-x-1/2 bg-surface-weak px-6 py-5 rounded-full text-center z-50">
+              <h3 className="text-32 font-pinkfong font-bold whitespace-nowrap">{currentQuestion.question}</h3>
+            </div>
+          )}
+
+          {/* 정답 통과 중 및 게임오버 시 해설 노출 */}
+          {(phase === 'CORRECT_PASSING' || phase === 'GAME_OVER') && currentQuestion?.explanation && (
+            <div className="absolute top-36 left-1/2 -translate-x-1/2 bg-surface-accent border border-border-accent flex items-center gap-3 px-6 py-4 rounded-2xl shadow-lg z-50 animate-fade-in-up">
+              <div className="w-6 h-[31px] flex-shrink-0 flex items-center justify-center">
+                <LightbulbIcon className="w-full h-full object-contain" />
+              </div>
+              <p className="font-pinkfong font-bold text-20 text-text-primary text-left break-keep">
+                {currentQuestion.explanation}
+              </p>
+            </div>
+          )}
+
+          {/* 게임오버 모달 */}
+          <GameOverModal
+            isOpen={isGameOverModalOpen}
+            correctCount={correctCount}
+            onRestart={handleRestart}
+            isMobile={false}
+          />
+        </div>
+      )}
 
 
       <Canvas
@@ -235,7 +319,7 @@ export default function GameScene() {
         <ambientLight intensity={1.5} />
         <directionalLight position={[0, 10, 5]} intensity={0.5} />
 
-        <CameraController />
+        <CameraController aspect={aspect} />
 
         <Suspense fallback={null}>
           <Background />

--- a/src/features/run-and-learn/components/game-scene/Pathway.tsx
+++ b/src/features/run-and-learn/components/game-scene/Pathway.tsx
@@ -3,15 +3,15 @@ import * as THREE from 'three';
 export default function Pathway() {
   return (
     <group>
-      {/* 1. Grass Ground Plane (Extends from z = -65 to z = +20 to cover camera's rear and front) */}
-      <mesh position={[0, -1.2, -22.5]} rotation={[-Math.PI / 2, 0, 0]}>
-        <planeGeometry args={[120, 85]} />
+      {/* 1. Grass Ground Plane (Extends from z = -80 to z = +40 to cover camera's rear and front) */}
+      <mesh position={[0, -1.2, -20.0]} rotation={[-Math.PI / 2, 0, 0]}>
+        <planeGeometry args={[160, 120]} />
         <meshBasicMaterial color="#b6ea82" side={THREE.DoubleSide} />
       </mesh>
 
       {/* 2. Sandy Pathway/Road (Laid flat on top, matching cards width: 4.62) */}
-      <mesh position={[0, -1.195, -22.5]} rotation={[-Math.PI / 2, 0, 0]}>
-        <planeGeometry args={[4.62, 85]} />
+      <mesh position={[0, -1.195, -20.0]} rotation={[-Math.PI / 2, 0, 0]}>
+        <planeGeometry args={[4.62, 120]} />
         <meshBasicMaterial color="#e6b485" side={THREE.DoubleSide} />
       </mesh>
     </group>

--- a/src/features/run-and-learn/components/start-screen/GameStartScreen.tsx
+++ b/src/features/run-and-learn/components/start-screen/GameStartScreen.tsx
@@ -1,13 +1,10 @@
 import { useEffect, useRef, useState } from 'react';
+import { cn } from '@/utils/cn';
 import StartTitle from './StartTitle';
 import StartScenery from './StartScenery';
 import StartButton from './StartButton';
 import GameButton from '../common/GameButton';
 import GameTutorialModal from './GameTutorialModal';
-
-// 피그마 기준 해상도
-const BASE_WIDTH = 1240;
-const BASE_HEIGHT = 890;
 
 interface GameStartScreenProps {
   onStart: () => void;
@@ -17,6 +14,7 @@ interface GameStartScreenProps {
 export default function GameStartScreen({ onStart, isLoading = false }: GameStartScreenProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const [scale, setScale] = useState(1);
+  const [isMobile, setIsMobile] = useState(false);
   const [isTutorialOpen, setIsTutorialOpen] = useState(false);
 
   useEffect(() => {
@@ -25,9 +23,21 @@ export default function GameStartScreen({ onStart, isLoading = false }: GameStar
 
     const observer = new ResizeObserver(([entry]) => {
       const { width, height } = entry.contentRect;
-      const scaleX = width / BASE_WIDTH;
-      const scaleY = height / BASE_HEIGHT;
-      setScale(Math.min(scaleX, scaleY));
+      const aspect = width / height;
+      const mobile = aspect < 1.2;
+      setIsMobile(mobile);
+
+      if (mobile) {
+        // 모바일(세로 카드 모드): 327 x 592 피그마 규격 기준
+        // 높이에 맞추고 좌우는 클리핑 (부모 aspect가 327:592이므로 사실상 꽉 참)
+        const scaleY = height / 592;
+        setScale(scaleY);
+      } else {
+        // PC/태블릿: 1240 x 890 피그마 규격 기준
+        const scaleX = width / 1240;
+        const scaleY = height / 890;
+        setScale(Math.min(scaleX, scaleY));
+      }
     });
 
     observer.observe(container);
@@ -35,24 +45,25 @@ export default function GameStartScreen({ onStart, isLoading = false }: GameStar
   }, []);
 
   return (
-    // 컨테이너: 부모(aspect-[1240/890])를 꽉 채움
+    // 컨테이너: 부모를 꽉 채움
     <div ref={containerRef} className="absolute inset-0 overflow-hidden z-20">
-      {/* 1240×890 고정 설계, scale로 통째로 축소 (동적 값이므로 style 허용) */}
+      {/* 피그마 프레임 크기에 맞춰 배치 후 scale로 비율 조정 */}
       <div
-        className="absolute w-[1240px] h-[890px] left-1/2 top-1/2 bg-[#d6f3ff] overflow-hidden"
+        className={cn(
+          "absolute left-1/2 top-1/2 bg-[#d6f3ff] overflow-hidden",
+          isMobile ? "w-[327px] h-[592px]" : "w-[1240px] h-[890px]"
+        )}
         style={{ 
           transform: `translate(-50%, -50%) scale(${scale})`,
           transformOrigin: 'center center'
         }}
       >
-        {/*
-          피그마 최상위 구조: flex-col, justify-between, items-center, pt-[40px]
-          ├── StartTitle  (상단 타이틀+설명)
-          ├── StartButton/GameButton (중앙 버튼들)
-          └── StartScenery (하단 씬 배경)
-        */}
-        <div className="flex flex-col items-center justify-between h-full pt-10">
-          <StartTitle />
+        <div className={cn(
+          "flex flex-col items-center justify-between h-full pt-10",
+          isMobile ? "pt-0" : "pt-10"
+        )}>
+          <StartTitle isMobile={isMobile} />
+          
           <div className="flex flex-row gap-4 items-center justify-center z-30">
             <GameButton
               variant="secondary"
@@ -63,10 +74,11 @@ export default function GameStartScreen({ onStart, isLoading = false }: GameStar
             </GameButton>
             <StartButton onStart={onStart} isLoading={isLoading} />
           </div>
-          <StartScenery />
+          
+          <StartScenery isMobile={isMobile} />
         </div>
 
-        {/* 게임 방법 설명 모달 (scale 축소 영역 내부로 진입하여 함께 축소되도록 함) */}
+        {/* 게임 방법 설명 모달 */}
         <GameTutorialModal
           isOpen={isTutorialOpen}
           onClose={() => setIsTutorialOpen(false)}

--- a/src/features/run-and-learn/components/start-screen/GameTutorialModal.tsx
+++ b/src/features/run-and-learn/components/start-screen/GameTutorialModal.tsx
@@ -9,21 +9,24 @@ interface GameTutorialModalProps {
 }
 
 /** 🎮 런앤런 게임 방법을 팝업 모달 형태로 보여주는 컴포넌트 */
-export default function GameTutorialModal({ isOpen, onClose }: GameTutorialModalProps) {
+export default function GameTutorialModal({
+  isOpen,
+  onClose,
+}: GameTutorialModalProps) {
   return (
     <Modal
       isOpen={isOpen}
       onCloseHandler={onClose}
       position="absolute"
-      className="bg-surface-weak w-120 p-10 overflow-hidden pointer-events-auto"
+      className="bg-surface-weak w-[295px] sm:w-120 max-w-[calc(100%-32px)] p-5 sm:p-10 overflow-hidden pointer-events-auto"
     >
       <div className="flex flex-col items-center gap-6 w-full">
         {/* 내부 튜토리얼 내용 */}
         <div className="flex flex-col items-start w-full">
           <div className="flex flex-col gap-5 items-start w-full">
             <div className="flex gap-3 items-end">
-              <GamepadIcon className="w-12 h-12" />
-              <h2 className="font-pinkfong font-normal text-36 text-text-primary m-0">
+              <GamepadIcon className="w-8 h-8 sm:w-12 sm:h-12" />
+              <h2 className="font-pinkfong font-normal text-28 sm:text-36 text-text-primary m-0">
                 게임 방법
               </h2>
             </div>
@@ -32,8 +35,8 @@ export default function GameTutorialModal({ isOpen, onClose }: GameTutorialModal
               <TutorialStep step={2} text="각 문에 적힌 보기 중 정답을 찾아요." />
 
               <TutorialStep step={3} text="달리는 잉듀를 이동해 정답 문으로 향해요.">
-                <li>A 키 또는 &larr; 키 : 왼쪽 이동</li>
-                <li>D 키 또는 &rarr; 키 : 오른쪽 이동</li>
+                <li>A / ← 키 또는 왼쪽 쓸기 : 왼쪽 이동</li>
+                <li>D / → 키 또는 오른쪽 쓸기 : 오른쪽 이동</li>
               </TutorialStep>
 
               <TutorialStep step={4} text="정답 문은 통과해 다음 문제로!" />
@@ -45,9 +48,8 @@ export default function GameTutorialModal({ isOpen, onClose }: GameTutorialModal
         {/* 닫기 버튼 */}
         <GameButton
           variant="primary"
-          size="md"
+          size="sm"
           onClick={onClose}
-          className="w-[180px] h-[54px] text-[24px]"
         >
           닫기
         </GameButton>

--- a/src/features/run-and-learn/components/start-screen/StartButton.tsx
+++ b/src/features/run-and-learn/components/start-screen/StartButton.tsx
@@ -5,7 +5,10 @@ interface StartButtonProps {
   isLoading?: boolean;
 }
 
-export default function StartButton({ onStart, isLoading = false }: StartButtonProps) {
+export default function StartButton({
+  onStart,
+  isLoading = false,
+}: StartButtonProps) {
   return (
     <GameButton
       onClick={onStart}

--- a/src/features/run-and-learn/components/start-screen/StartScenery.tsx
+++ b/src/features/run-and-learn/components/start-screen/StartScenery.tsx
@@ -5,10 +5,85 @@ import imgFlower from '@/assets/game/flower.svg';
 import imgShadowFlower from '@/assets/game/shadow_flower.svg';
 import imgRockLeft from '@/assets/game/rock_left.svg';
 import imgShadowRock from '@/assets/game/shadow_rock.svg';
+import imgStartMobileBg from '@/assets/game/start/start_mobile_bg.svg';
+import imgStartMobileIntersect from '@/assets/game/start/start_mobile_intersect.svg';
+
+interface StartSceneryProps {
+  isMobile?: boolean;
+}
 
 // 피그마: 하단 씬 영역 (relative + 배경 absolute 레이어 허용)
-// 배경(언덕/흙길)은 씬 전체를 덮는 배경 레이어이므로 absolute 허용 (GEMINI.md 허용 예외)
-export default function StartScenery() {
+export default function StartScenery({ isMobile = false }: StartSceneryProps) {
+  if (isMobile) {
+    return (
+      <div className="relative w-[327px] h-[250px] shrink-0 overflow-hidden select-none pointer-events-none">
+        {/* 1. 배경 산/바닥 (Vector) */}
+        <img
+          src={imgStartMobileBg}
+          alt=""
+          className="absolute left-0 top-[25px] w-[327px] h-[225px]"
+        />
+
+        {/* 2. 꽃 오른쪽 그림자 */}
+        <img
+          src={imgShadowFlower}
+          alt=""
+          className="absolute left-[238px] top-[45px] w-[53px] h-[19px] -scale-y-100 rotate-180"
+        />
+
+        {/* 3. 꽃 오른쪽 */}
+        <img
+          src={imgFlower}
+          alt=""
+          className="absolute left-[244px] top-0 w-[40px] h-[54px] -scale-y-100 rotate-180"
+        />
+
+        {/* 4. 바위 그림자 */}
+        <img
+          src={imgShadowRock}
+          alt=""
+          className="absolute left-[14px] top-[115px] w-[109px] h-[41px]"
+        />
+
+        {/* 5. 바위 */}
+        <img
+          src={imgRockLeft}
+          alt=""
+          className="absolute left-[31px] top-[97px] w-[86px] h-[52px]"
+        />
+
+        {/* 6. 꽃 왼쪽 그림자 */}
+        <img
+          src={imgShadowFlower}
+          alt=""
+          className="absolute left-[83px] top-[68px] w-[53px] h-[19px] -scale-y-100 rotate-180"
+        />
+
+        {/* 7. 꽃 왼쪽 */}
+        <img
+          src={imgFlower}
+          alt=""
+          className="absolute left-[89px] top-[23px] w-[40px] h-[54px] -scale-y-100 rotate-180"
+        />
+
+        {/* 8. Intersect 길 오버레이 */}
+        <img
+          src={imgStartMobileIntersect}
+          alt=""
+          className="absolute left-[33px] top-[72px] w-[294px] h-[178px]"
+        />
+
+        {/* 9. 달리는 병아리 캐릭터 */}
+        <img
+          src={imgStartCharacter}
+          alt="달리는 캐릭터"
+          className="absolute left-[136px] top-[70px] w-[160.7px] h-[155px]"
+        />
+      </div>
+    );
+  }
+
+  // PC 버전
   return (
     <div className="relative w-full h-[393px] shrink-0">
       {/* 1. Hill (초록 언덕 - 가장 뒤) */}

--- a/src/features/run-and-learn/components/start-screen/StartTitle.tsx
+++ b/src/features/run-and-learn/components/start-screen/StartTitle.tsx
@@ -12,10 +12,101 @@ const titleGradientStyle = {
   backgroundClip: 'text' as const,
 };
 
-export default function StartTitle() {
+interface StartTitleProps {
+  isMobile?: boolean;
+}
+
+export default function StartTitle({ isMobile = false }: StartTitleProps) {
+  if (isMobile) {
+    return (
+      <div className="relative flex flex-col items-center justify-center mt-10" style={{ width: '220px' }}>
+        {/* 모바일 장식 요소들 */}
+        {/* Star 2 (왼쪽 아래) */}
+        <div className="absolute left-[-13.6px] top-[86px] w-[53.865px] h-[53.865px] flex items-center justify-center pointer-events-none">
+          <StarSmallIcon className="w-[42.902px] h-[42.902px] rotate-[17.6deg]" />
+        </div>
+
+        {/* Star 3 (오른쪽 중간) */}
+        <div className="absolute left-[186.88px] top-[41px] w-[100.88px] h-[100.88px] flex items-center justify-center pointer-events-none">
+          <StarLargeIcon className="w-[82.635px] h-[82.635px] rotate-[104.68deg]" />
+        </div>
+
+        {/* Star 4 (왼쪽 위) */}
+        <div className="absolute left-[-50.78px] top-[-31.34px] w-[111.798px] h-[111.798px] flex items-center justify-center pointer-events-none">
+          <StarLargeIcon className="w-[79.15px] h-[79.15px] rotate-[47.83deg]" />
+        </div>
+
+        {/* DecoCurlRight (오른쪽 위) */}
+        <div className="absolute left-[210.4px] top-[-5.92px] w-[45.107px] h-[23.318px] flex items-center justify-center pointer-events-none">
+          <DecoCurlRightIcon className="w-[43.082px] h-[17.427px] rotate-[-8.09deg]" />
+        </div>
+
+        {/* DecoCurlLeft (왼쪽 중간) */}
+        <div className="absolute left-[-37.6px] top-[81px] w-[45.623px] h-[37.254px] flex items-center justify-center pointer-events-none">
+          <DecoCurlLeftIcon className="w-[43.12px] h-[17.054px] rotate-[-31.88deg]" />
+        </div>
+
+        {/* 제목 글자 영역 */}
+        <div className="flex gap-[20px] h-[108px] items-center justify-center relative shrink-0 z-10">
+          {/* 런 */}
+          <div className="relative flex items-center justify-center shrink-0 w-[74.905px] h-[108.155px]">
+            <span
+              className="absolute -rotate-9 not-italic leading-[108px] w-[75px] h-[108px] font-pinkfong font-bold text-[80px] text-[#452508] select-none text-center"
+              style={{ WebkitTextStroke: '8px #452508' }}
+            >
+              런
+            </span>
+            <span
+              className="-rotate-9 not-italic leading-[108px] w-[75px] h-[108px] font-pinkfong font-bold text-[80px] relative z-10 text-center"
+              style={titleGradientStyle}
+            >
+              런
+            </span>
+          </div>
+
+          {/* 앤 */}
+          <div className="relative flex items-center justify-center shrink-0 w-[50px] h-[108.155px]">
+            <span
+              className="absolute not-italic leading-[108px] w-[50px] h-[108px] font-pinkfong font-bold text-[50px] text-[#452508] select-none text-center"
+              style={{ WebkitTextStroke: '8px #452508' }}
+            >
+              앤
+            </span>
+            <span
+              className="not-italic leading-[108px] w-[50px] h-[108px] font-pinkfong font-bold text-[50px] relative z-10 text-center"
+              style={titleGradientStyle}
+            >
+              앤
+            </span>
+          </div>
+
+          {/* 런 */}
+          <div className="relative flex items-center justify-center shrink-0 w-[74.905px] h-[108.155px]">
+            <span
+              className="absolute rotate-9 not-italic leading-[108px] w-[75px] h-[108px] font-pinkfong font-bold text-[80px] text-[#452508] select-none text-center"
+              style={{ WebkitTextStroke: '8px #452508' }}
+            >
+              런
+            </span>
+            <span
+              className="rotate-9 not-italic leading-[108px] w-[75px] h-[108px] font-pinkfong font-bold text-[80px] relative z-10 text-center"
+              style={titleGradientStyle}
+            >
+              런
+            </span>
+          </div>
+        </div>
+
+        {/* 설명 문구 */}
+        <p className="shrink-0 not-italic leading-normal text-center text-[#452508] w-[215px] font-pinkfong font-normal text-16 mt-4 z-10">
+          다가오는 문, 오답을 피해 끝까지 달려봐!
+        </p>
+      </div>
+    );
+  }
+
+  // PC 버전 레이아웃
   return (
-    // 피그마: flex row, gap-20, py-[11px], items-center, justify-center
-    // 별/데코 장식들은 이 flex 컨테이너 기준으로 absolute overflow
     <div className="relative flex items-center justify-center gap-5 py-3">
 
       {/* ── 장식: 큰 별 왼쪽 (Figma: left-[-144px] top-[-38px] size-[266.94px] rotate-[47.83deg]) ── */}

--- a/src/features/run-and-learn/components/start-screen/TutorialStep.tsx
+++ b/src/features/run-and-learn/components/start-screen/TutorialStep.tsx
@@ -13,9 +13,9 @@ function TutorialStep({ step, text, children, className }: TutorialStepProps) {
   return (
     <div className={cn('flex gap-3 items-start', className)}>
       <StepBadge step={step} />
-      <div className="font-medium text-20 text-text-secondary">
+      <div className="font-medium text-14 sm:text-20 text-text-secondary">
         {text && <p className="m-0">{text}</p>}
-        {children && <ul className="mt-1 list-disc pl-6">{children}</ul>}
+        {children && <ul className="mt-1 list-disc pl-6 text-12 sm:text-16">{children}</ul>}
       </div>
     </div>
   );

--- a/src/utils/cn.ts
+++ b/src/utils/cn.ts
@@ -14,6 +14,7 @@ const customTwMerge = extendTailwindMerge({
         'text-32',
         'text-36',
         'text-50',
+        'text-80'
       ],
     },
   },


### PR DESCRIPTION
## ✨ PR 유형

- [x]  새로운 기능 추가
- [ ]  버그 수정
- [x]  UI 변경(스타일 파일 추가 및 수정 등)
- [ ]  문서 작성 및 수정
- [ ]  테스트 코드 추가
- [x]  코드에 영향을 주지 않는 변경사항 (변수명 변경, 오타 수정, 주석 추가 등)
- [ ]  기타 (설정 추가 등)

---

## ✅ 완료 작업 목록

- [x] **모바일 하단 탭 바 및 가변 카드 비율 레이아웃 구현** ([RunAndLearn.tsx](file:///Users/hanjieun/develop/eng-du/src/features/run-and-learn/RunAndLearn.tsx))
  - `1024px` 미만 모든 뷰포트에서 `게임/리더보드` 하단 탭 전환 기능 제공
  - 탭을 전환해도 진행 중인 게임 상태 및 세션이 초기화되지 않도록 DOM 유지 및 CSS `block`/`hidden` 활용 스위칭 적용
  - 모바일(768px 미만)에서는 `aspect-[327/592]` 고정 가로폭 적용, 태블릿(768px~1024px)에서는 `aspect-[1240/890]` 가로형 카드 비율 유동 매칭
- [x] **모바일 3D 카메라 뷰포트 최적화 및 터치 스와이프 조작 구현** ([GameScene.tsx](file:///Users/hanjieun/develop/eng-du/src/features/run-and-learn/components/game-scene/GameScene.tsx))
  - 좁은 세로 카드 영역 대응을 위해 카메라 FOV를 `26`에서 `65`로 자동 보정하여 도로 3레인 및 문제 문 시야 확보
  - 터치 스와이프 조작 시 화면이 밀리거나 아래로 흔들리는 브라우저 바운스/스크롤 방지를 위해 `touch-action: none` 및 `select-none` 설정 적용
  - 광각 카메라 줌아웃 상태에서 화면 하단 빈 공간 노출을 막기 위해 바닥 잔디밭 Z축 렌더링 길이를 `85`에서 `120`으로 확장 ([Pathway.tsx](file:///Users/hanjieun/develop/eng-du/src/features/run-and-learn/components/game-scene/Pathway.tsx))
- [x] **GameButton 내부 반응형 크기 내장화 및 폰트 유틸 확장** ([GameButton.tsx](file:///Users/hanjieun/develop/eng-du/src/features/run-and-learn/components/common/GameButton.tsx), [StartButton.tsx](file:///Users/hanjieun/develop/eng-du/src/features/run-and-learn/components/start-screen/StartButton.tsx))
  - 공통 버튼 컴포넌트 내부에 모바일/데스크톱 규격별 `size` 프리셋(`lg`, `md`, `sm`)을 직접 탑재해 외부 호출 구조 최적화
- [x] **피그마 모바일 규격 대응 327x592 시작 화면 및 에셋 구현**
  - 모바일 해상도 전용 배경 SVG 리소스 배치 및 프레임 내부 데코레이션/캐릭터 1:1 배치 마크업 ([GameStartScreen.tsx](file:///Users/hanjieun/develop/eng-du/src/features/run-and-learn/components/start-screen/GameStartScreen.tsx))
- [x] **GameOverModal 모바일 크기 최적화 및 스토리북 뷰포트 등록**
  - 모바일 화면에서 오버플로우가 나지 않도록 너비 제한(`max-w-[calc(100%-32px)]`) 및 반응형 폰트 축소 대응 ([GameOverModal.tsx](file:///Users/hanjieun/develop/eng-du/src/features/run-and-learn/components/game-scene/GameOverModal.tsx))
  - 스토리북 상에서 데스크톱/태블릿/모바일 각 기기 사이즈별로 즉각적인 화면 구성 및 버튼 반응성을 검증할 수 있도록 뷰포트 메타 파라미터 추가 ([GameOverModal.stories.tsx](file:///Users/hanjieun/develop/eng-du/src/features/run-and-learn/components/game-scene/GameOverModal.stories.tsx))

---

## 🤔 주요 고민 및 해결 과정

**[ 첫 번째 고민: 모바일 세로 뷰포트에서 3D Canvas 시야각 및 리소스 잘림 현상 ]**
- **문제점**: 모바일 세로 비율(`aspect < 1.2`) 카드 디자인 내에서 3D Canvas를 그대로 배치할 경우, 3개의 차선과 영단어 문이 좌우로 잘려 나감으로써 정상적인 게임 조작 및 플레이가 불가능해지는 한계가 존재했습니다.
- **해결 과정**:
  - 카메라 컨트롤러에서 모바일 뷰포트 진입 시 카메라의 수평 시야각(FOV)을 `26`에서 `65`로 광각 변경하는 보정 로직을 추가하여 도로 전체를 좁은 폭 화면에 정상적으로 우겨넣었습니다.
  - FOV 65도 확장 시 화면 하단 잔디밭 영역 끝부분이 하늘에 붕 떠 보이는 현상이 새로이 발생하여, `Pathway.tsx`의 잔디밭 Z축 렌더링 길이를 `85`에서 `120`으로 확장하고 시작 좌표를 보정하여 3D 배경이 빈 틈 없이 꽉 차도록 문제를 해결했습니다.

**[ 두 번째 고민: 터치 스와이프 조작 시 브라우저 바운스/스크롤 오작동 방지 ]**
- **문제점**: 모바일 브라우저의 기본 특성으로 인해 화면에서 손가락을 대고 좌우로 쓸 때(Swipe), 브라우저가 화면 자체를 드래그하거나 스크롤하려는 기본 바운스(Bounce) 동작이 격발되면서 텍스트가 파랗게 드래그되고 조작감이 극도로 망가지는 문제가 있었습니다.
- **해결 과정**:
  - 3D 캔버스 컨테이너에 `touch-action: none`을 설정하고 `select-none` 스타일을 바인딩하여 브라우저의 스크롤 기본 이벤트를 원천 차단하고 스와이프 동작이 오직 게임 캐릭터 레인 변경 이벤트로만 전달되도록 조작계를 안전하게 정밀 격리했습니다.
  - 아울러 아이패드나 터치스크린 지원 노트북처럼 키보드 조작과 터치 조작이 모두 활성화된 하이브리드 기기 환경을 고려하여, 가상 키 분기 대신 **통합 안내 문구**("A / ← 키 또는 왼쪽 쓸기")를 노출하여 사용성을 강화했습니다.

**[ 세 번째 고민: 하단 탭 스위칭 시 게임 세션 상태 보존 ]**
- **문제점**: 1024px 미만 반응형 하단 탭 바를 통해 리더보드로 이동 시 `<GameScene />` 컴포넌트가 DOM에서 언마운트되면, 플레이어의 누적 스코어 및 학습 흐름 데이터 세션이 초기화되는 문제가 예상되었습니다.
- **해결 과정**: 
  - 리더보드 전환 시 조건부 렌더링(`{activeTab === 'game' && ...}`) 대신 Tailwind CSS의 `block` / `hidden` 분기 기법을 활용해 돔 노드를 계속 유지하도록 했습니다. 이를 통해 리더보드를 확인하고 게임 탭으로 돌아오더라도 이전 게임 상태가 끊김 없이 실시간으로 이어집니다.
 
---

## 🍄‍🟫 관련 이슈

- Closes #87
- Related #78